### PR TITLE
chore: upgrade dinero.js to v2.0.0 stable

### DIFF
--- a/components/product-currency-symbol.tsx
+++ b/components/product-currency-symbol.tsx
@@ -1,12 +1,14 @@
-import { toFormat, type Dinero } from 'dinero.js';
+import { toSnapshot, type Dinero } from 'dinero.js';
 
 export const ProductCurrencySymbol = ({
   dinero,
 }: {
   dinero: Dinero<number>;
 }) => {
+  const { currency } = toSnapshot(dinero);
+
   let symbol = '';
-  switch (toFormat(dinero, ({ currency }) => currency.code)) {
+  switch (currency.code) {
     case 'GBP': {
       symbol = '£';
       break;

--- a/components/product-deal.tsx
+++ b/components/product-deal.tsx
@@ -1,5 +1,5 @@
 import { ProductCurrencySymbol } from '#/components/product-currency-symbol';
-import { toUnit, type Dinero } from 'dinero.js';
+import { toDecimal, type Dinero } from 'dinero.js';
 
 export const ProductDeal = ({
   price: priceRaw,
@@ -10,8 +10,8 @@ export const ProductDeal = ({
     amount: Dinero<number>;
   };
 }) => {
-  const discount = toUnit(discountRaw.amount);
-  const price = toUnit(priceRaw);
+  const discount = Number(toDecimal(discountRaw.amount));
+  const price = Number(toDecimal(priceRaw));
   const percent = Math.round(100 - (discount / price) * 100);
 
   return (

--- a/components/product-price.tsx
+++ b/components/product-price.tsx
@@ -2,7 +2,7 @@ import { Product } from '#/types/product';
 import { ProductCurrencySymbol } from '#/components/product-currency-symbol';
 import { ProductDeal } from '#/components/product-deal';
 import { ProductLighteningDeal } from '#/components/product-lightening-deal';
-import { multiply, toUnit, type Dinero } from 'dinero.js';
+import { multiply, toDecimal, type Dinero } from 'dinero.js';
 
 function isDiscount(obj: any): obj is { percent: number; expires?: number } {
   return typeof obj?.percent === 'number';
@@ -45,7 +45,7 @@ export const ProductPrice = ({
         <ProductCurrencySymbol dinero={price} />
       </div>
       <div className="text-lg font-bold leading-snug text-white">
-        {toUnit(price)}
+        {toDecimal(price)}
       </div>
     </div>
   );

--- a/components/product-split-payments.tsx
+++ b/components/product-split-payments.tsx
@@ -1,9 +1,9 @@
 import { ProductCurrencySymbol } from '#/components/product-currency-symbol';
-import { allocate, toUnit, up, type Dinero } from 'dinero.js';
+import { allocate, toDecimal, transformScale, up, type Dinero } from 'dinero.js';
 
 export const ProductSplitPayments = ({ price }: { price: Dinero<number> }) => {
   // only offer split payments for more expensive items
-  if (toUnit(price) < 150) {
+  if (Number(toDecimal(price)) < 150) {
     return null;
   }
 
@@ -11,7 +11,7 @@ export const ProductSplitPayments = ({ price }: { price: Dinero<number> }) => {
   return (
     <div className="text-sm text-gray-400">
       Or <ProductCurrencySymbol dinero={price} />
-      {toUnit(perMonth, { digits: 0, round: up })}/month for 3 months
+      {toDecimal(transformScale(perMonth, 0, up))}/month for 3 months
     </div>
   );
 };

--- a/components/product-used-price.tsx
+++ b/components/product-used-price.tsx
@@ -1,5 +1,5 @@
 import { Product } from '#/types/product';
-import { dinero, toUnit, up, type DineroSnapshot } from 'dinero.js';
+import { dinero, toDecimal, transformScale, up, type DineroSnapshot } from 'dinero.js';
 
 export const ProductUsedPrice = ({
   usedPrice: usedPriceRaw,
@@ -12,7 +12,7 @@ export const ProductUsedPrice = ({
     <div className="text-sm">
       <div className="text-gray-400">More buying choices</div>
       <div className="text-gray-200">
-        ${toUnit(usedPrice, { digits: 0, round: up })} (used)
+        ${toDecimal(transformScale(usedPrice, 0, up))} (used)
       </div>
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@heroicons/react": "2.1.5",
     "clsx": "2.1.1",
     "date-fns": "3.6.0",
-    "dinero.js": "2.0.0-alpha.8",
+    "dinero.js": "2.0.0",
     "geist": "1.3.1",
     "next": "15.6.0-canary.60",
     "react": "19.0.0-rc-8b08e99e-20240713",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 3.6.0
         version: 3.6.0
       dinero.js:
-        specifier: 2.0.0-alpha.8
-        version: 2.0.0-alpha.8
+        specifier: 2.0.0
+        version: 2.0.0
       geist:
         specifier: 1.3.1
         version: 1.3.1(next@15.6.0-canary.60(@babel/core@7.28.5)(react-dom@19.0.0-rc-8b08e99e-20240713(react@19.0.0-rc-8b08e99e-20240713))(react@19.0.0-rc-8b08e99e-20240713))
@@ -139,15 +139,6 @@ packages:
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
-
-  '@dinero.js/calculator-number@2.0.0-alpha.8':
-    resolution: {integrity: sha512-/L+N7g5DjcS6wlMb2hcOXWBKW2TGiG+vZDZr9ow0nsHUTdwtMarL1bmBH9fGldHhH2XsxcrjN9H+036yeNzh3Q==}
-
-  '@dinero.js/core@2.0.0-alpha.8':
-    resolution: {integrity: sha512-3jaw2j6J/SshlCZz5KhHkh8zP47HRmt9RpnjR0BJs2awpweVuZIyyX9qzGVUEVpml9IwzQ1U+YdXevhOxtcDgg==}
-
-  '@dinero.js/currencies@2.0.0-alpha.8':
-    resolution: {integrity: sha512-zApiqtuuPwjiM9LJA5/kNcT48VSHRiz2/mktkXjIpfxrJKzthXybUAgEenExIH6dYhLDgVmsLQZtZFOsdYl0Ag==}
 
   '@emnapi/core@1.7.1':
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
@@ -891,8 +882,9 @@ packages:
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
-  dinero.js@2.0.0-alpha.8:
-    resolution: {integrity: sha512-6bl+g6oh6iQ6vPR5Pd4qr7D+P5e51GYRUT3jl8HYqYeejYC5sd9OVTTbXC3WU7L25mAIbOm+diiTVz1rL4QLwg==}
+  dinero.js@2.0.0:
+    resolution: {integrity: sha512-UTbFNSTA+7PBFQrubw004/mGxH8GPLL7a4NKoZJGISd9Pwe9YQsxJw+gO5kYRef0EiMLOptE6DH1mMBev7eQjQ==}
+    engines: {node: '>=20.0.0'}
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
@@ -2210,16 +2202,6 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@dinero.js/calculator-number@2.0.0-alpha.8':
-    dependencies:
-      '@dinero.js/core': 2.0.0-alpha.8
-
-  '@dinero.js/core@2.0.0-alpha.8':
-    dependencies:
-      '@dinero.js/currencies': 2.0.0-alpha.8
-
-  '@dinero.js/currencies@2.0.0-alpha.8': {}
-
   '@emnapi/core@1.7.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
@@ -2939,11 +2921,7 @@ snapshots:
 
   didyoumean@1.2.2: {}
 
-  dinero.js@2.0.0-alpha.8:
-    dependencies:
-      '@dinero.js/calculator-number': 2.0.0-alpha.8
-      '@dinero.js/core': 2.0.0-alpha.8
-      '@dinero.js/currencies': 2.0.0-alpha.8
+  dinero.js@2.0.0: {}
 
   dlv@1.1.3: {}
 
@@ -3086,8 +3064,8 @@ snapshots:
       '@typescript-eslint/parser': 8.48.1(eslint@8.57.1)(typescript@5.5.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 7.0.1(eslint@8.57.1)
@@ -3106,7 +3084,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -3117,22 +3095,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.48.1(eslint@8.57.1)(typescript@5.5.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -3143,7 +3121,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@8.57.1)(typescript@5.5.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary

Upgrades `dinero.js` from `2.0.0-alpha.8` to `2.0.0` (stable release) and migrates to the updated API:

- **`toFormat` → `toSnapshot`**: `toFormat` was removed. Use `toSnapshot` to access `currency.code` directly
- **`toUnit` → `toDecimal`**: `toUnit` was removed. `toDecimal` returns a string representation (e.g., `"10.50"`)
- **`toUnit` rounding options → `transformScale` + rounding mode**: `toUnit(d, { digits: 0, round: up })` becomes `toDecimal(transformScale(d, 0, up))`